### PR TITLE
Use sensible defaults for the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A command line tool in Haskell to identify unused code.
 
-![Image of Unused Output](http://i.giphy.com/l39707ITHLsymwSiI.gif)
+![Image of Unused Output](http://i.giphy.com/3oEjHGgyV2EDdy1Ogw.gif)
 
 ## Using Unused
 

--- a/src/Unused/ResponseFilter.hs
+++ b/src/Unused/ResponseFilter.hs
@@ -1,8 +1,6 @@
 module Unused.ResponseFilter
-    ( withOneFile
-    , withOneOccurrence
+    ( withOneOccurrence
     , withLikelihoods
-    , oneFile
     , oneOccurence
     , ignoringPaths
     , isClassOrModule
@@ -15,9 +13,6 @@ import qualified Data.Map.Strict as Map
 import Data.List (isInfixOf)
 import Unused.Regex (matchRegex)
 import Unused.Types
-
-withOneFile :: ParseResponse -> ParseResponse
-withOneFile = applyFilter (const oneFile)
 
 withOneOccurrence :: ParseResponse -> ParseResponse
 withOneOccurrence = applyFilter (const oneOccurence)
@@ -35,9 +30,6 @@ ignoringPaths xs =
   where
     newMatches = filter (not . matchesPath . tmPath)
     matchesPath p = any (`isInfixOf` p) xs
-
-oneFile :: TermResults -> Bool
-oneFile = (== 1) . totalFileCount
 
 includesLikelihood :: [RemovalLikelihood] -> TermResults -> Bool
 includesLikelihood l = (`elem` l) . rLikelihood . trRemoval


### PR DESCRIPTION
Why?
====

By default, people want to see an actionable, comprehensive list without
having to pass any flags into the program.

Previously, to see everything with high likelihood you'd need to provide
`-a --likelihood high`. This commit changes the program so that's the default.

It also introduces a `--likelihood all` flag to see everything, so if
you want to opt into see it, you can. Finally, this changes `-a` (to see
everything) to `-s` (to see only single occurrences, which was the
previous default).