### PR TITLE
Parallelize search

### DIFF
--- a/src/Unused/CLI/ProgressIndicator.hs
+++ b/src/Unused/CLI/ProgressIndicator.hs
@@ -5,6 +5,7 @@ module Unused.CLI.ProgressIndicator
     , progressWithIndicator
     ) where
 
+import Control.Concurrent.ParallelIO
 import Unused.CLI.Util
 import Unused.CLI.ProgressIndicator.Types
 import Unused.CLI.ProgressIndicator.Internal
@@ -23,6 +24,6 @@ progressWithIndicator :: (a -> IO [b]) -> ProgressIndicator -> [a] -> IO [b]
 progressWithIndicator f i terms = do
     printPrefix i
     indicator <- start i $ length terms
-    concat <$> sequence (ioOps indicator) <* stop indicator
+    concat <$> parallel (ioOps indicator) <* stop indicator <* stopGlobalPool
   where
     ioOps i' = map (\t -> f t <* increment i') terms

--- a/unused.cabal
+++ b/unused.cabal
@@ -42,6 +42,7 @@ library
                      , terminal-progress-bar
                      , ansi-terminal
                      , unix
+                     , parallel-io
   ghc-options:         -Wall -Werror -O2
   default-language:    Haskell2010
 


### PR DESCRIPTION
Why?
====

Searching hundreds or thousands of tokens with ag can be slow; this
introduces parallel processing of search so results are returned more
quickly.

Analysis of Paperclip:

**Before:** `unused  3.57s user 5.97s system 166% cpu 5.739 total`
**After:** `unused  4.52s user 5.63s system 585% cpu 1.733 total`

Analysis of another internal application:

**Before:** `unused  30.25s user 73.35s system 204% cpu 50.755 total`
**After:** `unused  41.84s user 73.44s system 666% cpu 17.304 total`


