### PR TITLE
Extract views to a Views module

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -9,7 +9,8 @@ import Unused.TermSearch (SearchResults(..), fromResults)
 import Unused.ResultsClassifier
 import Unused.ResponseFilter (withOneOccurrence, withLikelihoods, ignoringPaths)
 import Unused.Grouping (CurrentGrouping(..), groupedResponses)
-import Unused.CLI (SearchRunner(..), withoutCursor, renderHeader, executeSearch, printMissingTagsFileError, printSearchResults, resetScreen, withInterruptHandler)
+import Unused.CLI (SearchRunner(..), withoutCursor, renderHeader, executeSearch, resetScreen, withInterruptHandler)
+import qualified Unused.CLI.Views as V
 import Unused.Cache
 import Unused.TagsSource
 
@@ -42,7 +43,7 @@ run options = withoutCursor $ do
     terms' <- calculateTagInput options
 
     case terms' of
-       (Left e) -> printMissingTagsFileError e
+       (Left e) -> V.missingTagsFileError e
        (Right terms) -> do
             renderHeader terms
 
@@ -59,7 +60,7 @@ run options = withoutCursor $ do
     return ()
 
 printResults :: Options -> TermMatchSet -> IO ()
-printResults options = printSearchResults . groupedResponses (oGrouping options) . optionFilters options
+printResults options = V.searchResults . groupedResponses (oGrouping options) . optionFilters options
 
 loadLanguageConfig :: IO [LanguageConfiguration]
 loadLanguageConfig = either (const []) id <$> loadConfig

--- a/src/Unused/CLI.hs
+++ b/src/Unused/CLI.hs
@@ -3,6 +3,4 @@ module Unused.CLI
     ) where
 
 import Unused.CLI.Search as X
-import Unused.CLI.MissingTagsFileError as X
-import Unused.CLI.SearchResult as X
 import Unused.CLI.Util as X

--- a/src/Unused/CLI/Search.hs
+++ b/src/Unused/CLI/Search.hs
@@ -6,6 +6,7 @@ module Unused.CLI.Search
 
 import Unused.TermSearch (SearchResults, search)
 import Unused.CLI.Util
+import qualified Unused.CLI.Views as V
 import Unused.CLI.ProgressIndicator
 
 data SearchRunner = SearchWithProgress | SearchWithoutProgress
@@ -13,25 +14,12 @@ data SearchRunner = SearchWithProgress | SearchWithoutProgress
 renderHeader :: [String] -> IO ()
 renderHeader terms = do
     resetScreen
-    printAnalysisHeader terms
+    V.analysisHeader terms
 
 executeSearch :: SearchRunner -> [String] -> IO SearchResults
 executeSearch runner terms = do
     renderHeader terms
     runSearch runner terms <* resetScreen
-
-printAnalysisHeader :: [String] -> IO ()
-printAnalysisHeader terms = do
-    setSGR [SetConsoleIntensity BoldIntensity]
-    putStr "Unused: "
-    setSGR [Reset]
-
-    putStr "analyzing "
-
-    setSGR [SetColor Foreground Dull Green]
-    putStr $ show $ length terms
-    setSGR [Reset]
-    putStr " terms"
 
 runSearch :: SearchRunner -> [String] -> IO SearchResults
 runSearch SearchWithProgress    = progressWithIndicator search createProgressBar

--- a/src/Unused/CLI/Views.hs
+++ b/src/Unused/CLI/Views.hs
@@ -1,0 +1,8 @@
+module Unused.CLI.Views
+    ( module X
+    ) where
+
+import Unused.CLI.Views.NoResultsFound as X
+import Unused.CLI.Views.AnalysisHeader as X
+import Unused.CLI.Views.MissingTagsFileError as X
+import Unused.CLI.Views.SearchResult as X

--- a/src/Unused/CLI/Views/AnalysisHeader.hs
+++ b/src/Unused/CLI/Views/AnalysisHeader.hs
@@ -1,0 +1,18 @@
+module Unused.CLI.Views.AnalysisHeader
+    ( analysisHeader
+    ) where
+
+import Unused.CLI.Util
+
+analysisHeader :: [String] -> IO ()
+analysisHeader terms = do
+    setSGR [SetConsoleIntensity BoldIntensity]
+    putStr "Unused: "
+    setSGR [Reset]
+
+    putStr "analyzing "
+
+    setSGR [SetColor Foreground Dull Green]
+    putStr $ show $ length terms
+    setSGR [Reset]
+    putStr " terms"

--- a/src/Unused/CLI/Views/MissingTagsFileError.hs
+++ b/src/Unused/CLI/Views/MissingTagsFileError.hs
@@ -1,12 +1,12 @@
-module Unused.CLI.MissingTagsFileError
-    ( printMissingTagsFileError
+module Unused.CLI.Views.MissingTagsFileError
+    ( missingTagsFileError
     ) where
 
 import Unused.TagsSource
 import Unused.CLI.Util
 
-printMissingTagsFileError :: TagSearchOutcome -> IO ()
-printMissingTagsFileError e = do
+missingTagsFileError :: TagSearchOutcome -> IO ()
+missingTagsFileError e = do
     setSGR [SetColor Background Vivid Red]
     setSGR [SetColor Foreground Vivid White]
     setSGR [SetConsoleIntensity BoldIntensity]
@@ -45,4 +45,3 @@ printOutcomeMessage :: TagSearchOutcome -> IO ()
 printOutcomeMessage (TagsFileNotFound directoriesSearched) = do
     putStrLn "Looked for a 'tags' file in the following directories:\n"
     mapM_ (\d -> putStrLn $ "* " ++ d) directoriesSearched
-

--- a/src/Unused/CLI/Views/NoResultsFound.hs
+++ b/src/Unused/CLI/Views/NoResultsFound.hs
@@ -1,0 +1,12 @@
+module Unused.CLI.Views.NoResultsFound
+    ( noResultsFound
+    ) where
+
+import Unused.CLI.Util
+
+noResultsFound :: IO ()
+noResultsFound = do
+    setSGR   [SetColor Foreground Dull Green]
+    setSGR   [SetConsoleIntensity BoldIntensity]
+    putStrLn "Unused found no results"
+    setSGR   [Reset]

--- a/src/Unused/CLI/Views/SearchResult/ColumnFormatter.hs
+++ b/src/Unused/CLI/Views/SearchResult/ColumnFormatter.hs
@@ -1,4 +1,4 @@
-module Unused.CLI.SearchResult.ColumnFormatter
+module Unused.CLI.Views.SearchResult.ColumnFormatter
     ( ColumnFormat(..)
     , buildColumnFormatter
     ) where

--- a/unused.cabal
+++ b/unused.cabal
@@ -37,10 +37,13 @@ library
                      , Unused.TagsSource
                      , Unused.CLI
                      , Unused.CLI.Search
-                     , Unused.CLI.MissingTagsFileError
-                     , Unused.CLI.SearchResult
-                     , Unused.CLI.SearchResult.ColumnFormatter
                      , Unused.CLI.Util
+                     , Unused.CLI.Views
+                     , Unused.CLI.Views.NoResultsFound
+                     , Unused.CLI.Views.AnalysisHeader
+                     , Unused.CLI.Views.MissingTagsFileError
+                     , Unused.CLI.Views.SearchResult
+                     , Unused.CLI.Views.SearchResult.ColumnFormatter
                      , Unused.CLI.ProgressIndicator
                      , Unused.CLI.ProgressIndicator.Internal
                      , Unused.CLI.ProgressIndicator.Types


### PR DESCRIPTION
Why?
====

View logic was scattered all over the place; this introduces a views
module to encapsulate any corresponding view work into one spot.