### PR TITLE
Load custom configs

### DIFF
--- a/src/Unused/CLI/Views.hs
+++ b/src/Unused/CLI/Views.hs
@@ -5,4 +5,5 @@ module Unused.CLI.Views
 import Unused.CLI.Views.NoResultsFound as X
 import Unused.CLI.Views.AnalysisHeader as X
 import Unused.CLI.Views.MissingTagsFileError as X
+import Unused.CLI.Views.InvalidConfigError as X
 import Unused.CLI.Views.SearchResult as X

--- a/src/Unused/CLI/Views/InvalidConfigError.hs
+++ b/src/Unused/CLI/Views/InvalidConfigError.hs
@@ -1,0 +1,27 @@
+module Unused.CLI.Views.InvalidConfigError
+    ( invalidConfigError
+    ) where
+
+import Unused.CLI.Util
+import Unused.ResultsClassifier (ParseConfigError(..))
+
+invalidConfigError :: [ParseConfigError] -> IO ()
+invalidConfigError es = do
+    setSGR [SetColor Background Vivid Red]
+    setSGR [SetColor Foreground Vivid White]
+    setSGR [SetConsoleIntensity BoldIntensity]
+
+    putStrLn "\nThere was a problem with the following config file(s):\n"
+
+    setSGR [Reset]
+
+    mapM_ configError es
+
+    setSGR [Reset]
+
+configError :: ParseConfigError -> IO ()
+configError ParseConfigError{ pcePath = path, pceParseError = msg} = do
+    setSGR [SetConsoleIntensity BoldIntensity]
+    putStrLn path
+    setSGR [Reset]
+    putStrLn $ "    " ++ msg

--- a/src/Unused/ResultsClassifier/Config.hs
+++ b/src/Unused/ResultsClassifier/Config.hs
@@ -1,15 +1,45 @@
 module Unused.ResultsClassifier.Config
     ( loadConfig
+    , loadAllConfigurations
     ) where
 
 import qualified Data.Yaml as Y
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as C
+import qualified Data.Either as E
+import qualified Data.Bifunctor as B
 import System.FilePath ((</>))
+import System.Directory (getHomeDirectory)
 import Paths_unused (getDataFileName)
-import Unused.ResultsClassifier.Types (LanguageConfiguration)
+import Unused.ResultsClassifier.Types (LanguageConfiguration, ParseConfigError(..))
+import Unused.Util (readIfFileExists)
 
 loadConfig :: IO (Either String [LanguageConfiguration])
 loadConfig = Y.decodeEither <$> readConfig
+
+loadAllConfigurations :: IO (Either [ParseConfigError] [LanguageConfiguration])
+loadAllConfigurations = do
+    homeDir <- getHomeDirectory
+
+    defaultConfig <- addSourceToLeft "default config" <$> loadConfig
+    localConfig <- loadConfigFromFile ".unused.yml"
+    userConfig <- loadConfigFromFile $ homeDir </> ".unused.yml"
+
+    let (lefts, rights) = E.partitionEithers [defaultConfig, localConfig, userConfig]
+
+    if not (null lefts)
+        then return $ Left lefts
+        else return $ Right $ concat rights
+
+loadConfigFromFile :: String -> IO (Either ParseConfigError [LanguageConfiguration])
+loadConfigFromFile path = do
+    file <- fmap C.pack <$> readIfFileExists path
+    return $ case file of
+        Nothing -> Right []
+        Just body -> addSourceToLeft path $ Y.decodeEither body
+
+addSourceToLeft :: String -> Either String c -> Either ParseConfigError c
+addSourceToLeft source = B.first (ParseConfigError source)
 
 readConfig :: IO BS.ByteString
 readConfig = getDataFileName ("data" </> "config.yml") >>= BS.readFile

--- a/unused.cabal
+++ b/unused.cabal
@@ -43,6 +43,7 @@ library
                      , Unused.CLI.Views.NoResultsFound
                      , Unused.CLI.Views.AnalysisHeader
                      , Unused.CLI.Views.MissingTagsFileError
+                     , Unused.CLI.Views.InvalidConfigError
                      , Unused.CLI.Views.SearchResult
                      , Unused.CLI.Views.SearchResult.ColumnFormatter
                      , Unused.CLI.ProgressIndicator
@@ -77,6 +78,8 @@ executable unused
   build-depends:       base
                      , unused
                      , optparse-applicative
+                     , mtl
+                     , transformers
   default-language:    Haskell2010
 
 test-suite unused-test


### PR DESCRIPTION
Why?
====

Developers should be able to introduce additional configuration at a machine
and project level to help weed out false positives.

This introduces additional configuration loading to look for ~/.unused.yml and
PROJECT_ROOT/.unused.yml and load either/both of those files, if present.

If the files don't exist, no problem. If there's a syntax error, the program
will halt and the user will be notified.

This needs documentation around the yaml format for config so people understand
what the options are. Might be good to include some examples for Rails ones,
e.g. Policy objects from Pundit, or AM::S.