### PR TITLE
Introduce a monad transformer stack for the application

### DIFF
--- a/app/App.hs
+++ b/app/App.hs
@@ -1,0 +1,133 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module App
+    ( Options(..)
+    , runProgram
+    ) where
+
+import qualified Data.Bifunctor as B
+import Control.Monad.Reader
+import Control.Monad.Except
+import Unused.Grouping (CurrentGrouping(..), groupedResponses)
+import Unused.Types (TermMatchSet, RemovalLikelihood(..))
+import Unused.TermSearch (SearchResults(..), fromResults)
+import Unused.ResponseFilter (withOneOccurrence, withLikelihoods, ignoringPaths)
+import Unused.Cache
+import Unused.TagsSource
+import Unused.ResultsClassifier
+import Unused.Aliases (termsAndAliases)
+import Unused.Parser (parseResults)
+import Unused.CLI (SearchRunner(..), renderHeader, executeSearch, withRuntime)
+import qualified Unused.CLI.Views as V
+
+type AppConfig = MonadReader Options
+
+data AppError
+    = TagError TagSearchOutcome
+    | InvalidConfigError [ParseConfigError]
+
+newtype App a = App {
+    runApp :: ReaderT Options (ExceptT AppError IO) a
+} deriving (Monad, Functor, Applicative, AppConfig, MonadError AppError, MonadIO)
+
+data Options = Options
+    { oSearchRunner :: SearchRunner
+    , oSingleOccurrenceMatches :: Bool
+    , oLikelihoods :: [RemovalLikelihood]
+    , oAllLikelihoods :: Bool
+    , oIgnoredPaths :: [String]
+    , oGrouping :: CurrentGrouping
+    , oWithoutCache :: Bool
+    , oFromStdIn :: Bool
+    }
+
+runProgram :: Options -> IO ()
+runProgram options = withRuntime $
+    runExceptT (runReaderT (runApp run) options) >>= either renderError return
+
+run :: App ()
+run = do
+    terms <- termsWithAlternatesFromConfig
+
+    liftIO $ renderHeader terms
+    results <- withCache . (`executeSearch` terms) =<< searchRunner
+
+    printResults . (`parseResults` results) =<< loadAllConfigs
+
+termsWithAlternatesFromConfig :: App [String]
+termsWithAlternatesFromConfig = do
+    aliases <- concatMap lcTermAliases <$> loadAllConfigs
+    terms <- calculateTagInput
+
+    return $ termsAndAliases aliases terms
+
+renderError :: AppError -> IO ()
+renderError (TagError e) = V.missingTagsFileError e
+renderError (InvalidConfigError e) = V.invalidConfigError e
+
+printResults :: TermMatchSet -> App ()
+printResults ts = do
+    filters <- optionFilters ts
+    grouping <- groupingOptions
+    liftIO $ V.searchResults $ groupedResponses grouping filters
+
+loadAllConfigs :: App [LanguageConfiguration]
+loadAllConfigs = do
+    configs <- liftIO (B.first InvalidConfigError <$> loadAllConfigurations)
+    either throwError return configs
+
+calculateTagInput :: App [String]
+calculateTagInput = do
+    tags <- liftIO . fmap (B.first TagError) . loadTags =<< readFromStdIn
+    either throwError return tags
+  where
+    loadTags b = if b then loadTagsFromPipe else loadTagsFromFile
+
+withCache :: IO SearchResults -> App SearchResults
+withCache f =
+    liftIO . operateCache =<< runWithCache
+  where
+    operateCache b = if b then withCache' f else f
+    withCache' = fmap SearchResults . cached "term-matches" . fmap fromResults
+
+optionFilters :: AppConfig m => TermMatchSet -> m TermMatchSet
+optionFilters tms = foldl (>>=) (pure tms) matchSetFilters
+  where
+    matchSetFilters =
+        [ singleOccurrenceFilter
+        , likelihoodsFilter
+        , ignoredPathsFilter
+        ]
+
+singleOccurrenceFilter :: AppConfig m => TermMatchSet -> m TermMatchSet
+singleOccurrenceFilter tms = do
+    allowsSingleOccurrence <- oSingleOccurrenceMatches <$> ask
+    return $ if allowsSingleOccurrence
+        then withOneOccurrence tms
+        else tms
+
+likelihoodsFilter :: AppConfig m => TermMatchSet -> m TermMatchSet
+likelihoodsFilter tms =
+     withLikelihoods . likelihoods <$> ask <*> pure tms
+  where
+    likelihoods options
+        | oAllLikelihoods options = [High, Medium, Low]
+        | null $ oLikelihoods options = [High]
+        | otherwise = oLikelihoods options
+
+ignoredPathsFilter :: AppConfig m => TermMatchSet -> m TermMatchSet
+ignoredPathsFilter tms = ignoringPaths . oIgnoredPaths <$> ask <*> pure tms
+
+readFromStdIn :: AppConfig m => m Bool
+readFromStdIn = oFromStdIn <$> ask
+
+groupingOptions :: AppConfig m => m CurrentGrouping
+groupingOptions = oGrouping <$> ask
+
+searchRunner :: AppConfig m => m SearchRunner
+searchRunner = oSearchRunner <$> ask
+
+runWithCache :: AppConfig m => m Bool
+runWithCache = not . oWithoutCache <$> ask

--- a/unused.cabal
+++ b/unused.cabal
@@ -80,6 +80,7 @@ executable unused
                      , optparse-applicative
                      , mtl
                      , transformers
+  other-modules:       App
   default-language:    Haskell2010
 
 test-suite unused-test


### PR DESCRIPTION
The app has continued to grow, to a point where it could've been using ReaderT
(for all the setup around the app for Options from the CLI), and it was already
using ExceptT to handle issues with parsing or finding a tags file.

This introduces an `App` stack rolling up this behavior, and extracts
interactions with `Options` into separate, well-named functions.