### PR TITLE
Add note about generating tags file

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ In an application where the tags file exists, run:
 unused
 ```
 
+If you don't have a tags file, you can generate one by running:
+```sh
+ctags -R .
+```
+
 If you want to specify a custom tags file, or load tokens from somewhere else,
 run:
 


### PR DESCRIPTION
I installed `unused` and hoped it would Just Work™. Instead I got a 'There was a problem finding a tags file.' error message.

Would be nice to add this line to that error message above, but this PR just adds a note to the README.