### PR TITLE
Remove columns displaying occurrence/file count

### DIFF
--- a/src/Unused/CLI/Views/SearchResult/ColumnFormatter.hs
+++ b/src/Unused/CLI/Views/SearchResult/ColumnFormatter.hs
@@ -4,17 +4,16 @@ module Unused.CLI.Views.SearchResult.ColumnFormatter
     ) where
 
 import Text.Printf (printf)
-import Unused.Types (TermResults(..), TermMatch(..), totalFileCount, totalOccurrenceCount)
+import Unused.Types (TermResults(..), TermMatch(..))
 
 data ColumnFormat = ColumnFormat
     { cfPrintTerm :: String -> String
     , cfPrintPath :: String -> String
-    , cfPrintNumber :: Int -> String
     }
 
 buildColumnFormatter :: [TermResults] -> ColumnFormat
 buildColumnFormatter r =
-    ColumnFormat (printf $ termFormat r) (printf $ pathFormat r) (printf $ numberFormat r)
+    ColumnFormat (printf $ termFormat r) (printf $ pathFormat r)
 
 termFormat :: [TermResults] -> String
 termFormat rs =
@@ -29,17 +28,3 @@ pathFormat rs =
   where
     pathWidth = maximum $ pathLength =<< trMatches =<< rs
     pathLength = return . length . tmPath
-
-numberFormat :: [TermResults] -> String
-numberFormat rs =
-    "%" ++ show numberWidth ++ "d"
-  where
-    numberWidth = maximum [fileWidth, occurrenceWidth]
-    fileWidth = maximum $ fileLength =<< rs
-    occurrenceWidth = maximum $ occurrenceLength =<< rs
-    fileLength = return . numberLength . totalFileCount
-    occurrenceLength = return . numberLength . totalOccurrenceCount
-
-numberLength :: Int -> Int
-numberLength i =
-    1 + floor (logBase 10 $ fromIntegral i :: Double)

--- a/src/Unused/CLI/Views/SearchResult/TableResult.hs
+++ b/src/Unused/CLI/Views/SearchResult/TableResult.hs
@@ -6,24 +6,18 @@ import           Control.Monad (forM_)
 import           Unused.CLI.Util
 import qualified Unused.CLI.Views.SearchResult.Internal as SR
 import qualified Unused.CLI.Views.SearchResult.Types as SR
-import           Unused.Types (TermResults, TermMatch(..), tmDisplayTerm, totalFileCount, totalOccurrenceCount)
+import           Unused.Types (TermResults, TermMatch(..), tmDisplayTerm)
 
 printTable :: TermResults -> [TermMatch] -> SR.ResultsPrinter ()
 printTable r ms = do
     cf <- SR.columnFormat
     let printTerm = SR.cfPrintTerm cf
     let printPath = SR.cfPrintPath cf
-    let printNumber = SR.cfPrintNumber cf
 
     SR.liftIO $ forM_ ms $ \m -> do
         setSGR [SetColor Foreground Dull (SR.termColor r)]
         setSGR [SetConsoleIntensity NormalIntensity]
         putStr $ "     " ++ printTerm (tmDisplayTerm m)
-        setSGR [Reset]
-
-        setSGR [SetColor Foreground Vivid Cyan]
-        setSGR [SetConsoleIntensity NormalIntensity]
-        putStr $ "  " ++ printNumber (totalFileCount r) ++ ", " ++ printNumber (totalOccurrenceCount r)
         setSGR [Reset]
 
         setSGR [SetColor Foreground Dull Cyan]


### PR DESCRIPTION
These columns were not well-explained and, with limited space for
headers, often led to confusion.

This removes the columns. The data is still displayed in the more
verbose output (currently visible when seeing corresponding commit SHAs,
via the `--commits #` flag).

Closes #60