### PR TITLE
Search for literal strings in Git commits

### DIFF
--- a/src/Unused/GitContext.hs
+++ b/src/Unused/GitContext.hs
@@ -29,5 +29,5 @@ logToGitContext =
 
 gitLogSearchFor :: Int -> [String] -> IO GitOutput
 gitLogSearchFor commitCount ts = do
-  (_, results, _) <- P.readProcessWithExitCode "git" ["log", "-G", L.intercalate "|" ts, "--oneline", "-n", show commitCount] ""
+  (_, results, _) <- P.readProcessWithExitCode "git" ["log", "-S", L.intercalate "|" ts, "--oneline", "-n", show commitCount] ""
   return $ GitOutput results

--- a/src/Unused/GitContext.hs
+++ b/src/Unused/GitContext.hs
@@ -33,5 +33,5 @@ gitLogSearchFor commitCount ts = do
     return $ GitOutput results
   where
     gitCommand :: Int -> [String] -> [String]
-    gitCommand commitCount [t] = ["log", "-S", t, "--oneline", "-n", show commitCount]
-    gitCommand commitCount ts = ["log", "-G", L.intercalate "|" ts, "--oneline", "-n", show commitCount]
+    gitCommand commitCount' [t] = ["log", "-S", t, "--oneline", "-n", show commitCount']
+    gitCommand commitCount' ts' = ["log", "-G", L.intercalate "|" ts', "--oneline", "-n", show commitCount']

--- a/src/Unused/GitContext.hs
+++ b/src/Unused/GitContext.hs
@@ -32,6 +32,6 @@ gitLogSearchFor commitCount ts = do
     (_, results, _) <- P.readProcessWithExitCode "git" (gitCommand commitCount ts) ""
     return $ GitOutput results
   where
-    gitCommand :: Int [String] -> [String]
+    gitCommand :: Int -> [String] -> [String]
     gitCommand commitCount [t] = ["log", "-S", t, "--oneline", "-n", show commitCount]
     gitCommand commitCount ts = ["log", "-G", L.intercalate "|" ts, "--oneline", "-n", show commitCount]

--- a/src/Unused/GitContext.hs
+++ b/src/Unused/GitContext.hs
@@ -29,5 +29,6 @@ logToGitContext =
 
 gitLogSearchFor :: Int -> [String] -> IO GitOutput
 gitLogSearchFor commitCount ts = do
-  (_, results, _) <- P.readProcessWithExitCode "git" ["log", "-S", L.intercalate "|" ts, "--oneline", "-n", show commitCount] ""
+  let gitLogFlag = if length ts == 1 then "-S" else "-G"
+  (_, results, _) <- P.readProcessWithExitCode "git" ["log", gitLogFlag, L.intercalate "|" ts, "--oneline", "-n", show commitCount] ""
   return $ GitOutput results

--- a/src/Unused/GitContext.hs
+++ b/src/Unused/GitContext.hs
@@ -29,6 +29,9 @@ logToGitContext =
 
 gitLogSearchFor :: Int -> [String] -> IO GitOutput
 gitLogSearchFor commitCount ts = do
-  let gitLogFlag = if length ts == 1 then "-S" else "-G"
-  (_, results, _) <- P.readProcessWithExitCode "git" ["log", gitLogFlag, L.intercalate "|" ts, "--oneline", "-n", show commitCount] ""
-  return $ GitOutput results
+    (_, results, _) <- P.readProcessWithExitCode "git" (gitCommand commitCount ts) ""
+    return $ GitOutput results
+  where
+    gitCommand :: Int [String] -> [String]
+    gitCommand commitCount [t] = ["log", "-S", t, "--oneline", "-n", show commitCount]
+    gitCommand commitCount ts = ["log", "-G", L.intercalate "|" ts, "--oneline", "-n", show commitCount]


### PR DESCRIPTION
`-G` treats its argument as a regex, while `-S` treats it as a literal string.

Why use `-S`?

* Guaranteed-accurate results for methods with a special regex character in them, like Ruby's predicate methods (`foo?`).
* It's faster: in a codebase with 35,000+ commits and 254,000 lines of code, running `git log -S` (outside of unused, just on the command line) completes in half the time or less.
    - When the filesystem is under high load (e.g. when running Unused), `-S` with a unique class string takes 23 seconds and `-G` takes 56 seconds.
    - When not under high load, `-S` takes 4 seconds and `-G` takes 9 seconds.
    - When I added a question mark to the end of the string to trigger regex parsing, `-G` took twice as long as before and `-S` stayed the same.