### PR TITLE
Enable Hackage friendly stack.yaml settings

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -35,3 +35,5 @@ extra-package-dbs: []
 
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
+
+pvp-bounds: both


### PR DESCRIPTION
This will help keeping `unused`'s install-plan from bitrotting over time and therefore avoid our Haddock doc builder failing to rebuild docs, as well as users running into compile errors, and last but not least reduce the overhead for us Hackage Trustees having to step in and fixup .cabal files :-)

(see also documentation at https://docs.haskellstack.org/en/stable/yaml_configuration/#pvp-bounds)

See also https://matrix.hackage.haskell.org/package/unused which shows that most install-plans for `unused` have already bitrotten